### PR TITLE
Update JSSImporter path to reflect changes in JSSImporter 1.1.0

### DIFF
--- a/spruce.py
+++ b/spruce.py
@@ -38,7 +38,7 @@ from Foundation import (NSData,
                         NSPropertyListXMLFormat_v1_0)
 # pylint: enable=no-name-in-module
 
-sys.path.insert(0, '/Library/Application Support/JSSImporter')
+sys.path.insert(0, '/Library/AutoPkg/JSSImporter')
 import requests
 import jss
 # Ensure that python-jss dependency is at minimum version


### PR DESCRIPTION
Spruce fails to import requests as the paths have been changed